### PR TITLE
Add scraped page archiver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,11 @@
 # Find out more: https://morph.io/documentation/ruby
 
 source "https://rubygems.org"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby "2.0.0"
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
+gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby", branch: "morph_defaults"
 gem "execjs"
 gem "pry"
 gem "colorize"

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby '2.0.0'
 
-gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby',
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'
 gem 'execjs'
 gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -2,16 +2,17 @@
 # specified here will be installed and made available to your morph.io scraper.
 # Find out more: https://morph.io/documentation/ruby
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby "2.0.0"
+ruby '2.0.0'
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby", branch: "morph_defaults"
-gem "execjs"
-gem "pry"
-gem "colorize"
-gem "nokogiri"
-gem "open-uri-cached"
-gem "fuzzy_match"
+gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby',
+                   branch: 'morph_defaults'
+gem 'execjs'
+gem 'pry'
+gem 'colorize'
+gem 'nokogiri'
+gem 'open-uri-cached'
+gem 'fuzzy_match'
 gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gem "colorize"
 gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
+gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,13 @@
 GIT
-  remote: https://github.com/openaustralia/scraperwiki-ruby.git
+  remote: https://github.com/everypolitician/scraped_page_archive.git
+  revision: 28f93d74b1c11ef01463ad0e7f874050d2e7fc73
+  specs:
+    scraped_page_archive (0.5.0)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+
+GIT
+  remote: https://github.com/openaustralia/scraperwiki-ruby
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
   specs:
@@ -10,11 +18,17 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     coderay (1.1.0)
     colorize (0.7.7)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     execjs (2.5.2)
     fuzzy_match (2.1.0)
-    httpclient (2.6.0.1)
+    git (1.3.0)
+    hashdiff (0.3.0)
+    httpclient (2.8.2.4)
     method_source (0.8.2)
     mini_portile (0.6.2)
     nokogiri (1.6.6.2)
@@ -24,10 +38,20 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.4)
+    safe_yaml (1.0.4)
     slop (3.6.0)
-    sqlite3 (1.3.10)
-    sqlite_magic (0.0.3)
+    sqlite3 (1.3.12)
+    sqlite_magic (0.0.6)
       sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -39,4 +63,11 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  scraped_page_archive!
   scraperwiki!
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
       vcr-archive (~> 0.3.0)
 
 GIT
-  remote: https://github.com/openaustralia/scraperwiki-ruby
+  remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
   specs:

--- a/scraper.rb
+++ b/scraper.rb
@@ -3,12 +3,13 @@
 
 require 'scraperwiki'
 require 'nokogiri'
-require 'open-uri'
+# require 'open-uri'
 require 'colorize'
 
 require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 class String
   def tidy


### PR DESCRIPTION
Mentioned in issue: https://github.com/everypolitician/everypolitician-data/issues/20544

# Scraper change checklist

* [ ] ~scraper is on Morph.io under the "everypolitician-scrapers" group~
* [x] scraper's GitHub "Website" link points at morph.io page
* [ ] scraper is set to auto-run
@tmtmtmtm This needs setting in Morph.
* [ ] ~~scraper has webhook set _(usually only set on Wikidata person-data scrapers)_~~

# Scraped page archive
* [x] scraper uses scraped archive gem (unless upstream source has its own archive)
* [x] repo URL uses `https` not `git@` (until [#37 is solved](https://github.com/everypolitician/scraped_page_archive/issues/37)) 
* [x] all gemfile links are secure (e.g., use https)
* [ ] morph is configured to write to GitHub ("secret" environment vars)
@tmtmtmtm The scraper's ENV variables need configuring on Morph.
* [x] pages are archived in new branch of correct scraper repo (yay!)

### Gemfile change:
* [x] all links are secure
* [x] links to Github use `github:` protocol, not simply `git:`
* [x] formatting is consistent with our normal Rubocop setup